### PR TITLE
Add alias instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,29 @@
 ## Get started
 ### Usage
 1. Clone this repository: 
-```
+```zsh
 $ git clone https://github.com/JBYT27/zsq.git
 ```
+2. Adding an alias
+Adding an alias is different on different Operating Systems. Check yours below!
 
-2. Run z^2
+#### macOS/Linux
+Find your `.zshrc` or `.bashrc` files and add the following code:
+```zsh
+alias zsq="python $HOME/zsq/main.py"
+```
+
+#### Windows
+
+
+---
+
+
+3. Run z^2
 
 Create a file named `index.zsq`, which will contain all of your code. Then enter the following in the shell:
-```
-$ cd zsq
-$ python main.py
+```zsh
+$ zsq index.zsq
 ```
 Enter the filepath, and now you're done!
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 ```zsh
 $ git clone https://github.com/JBYT27/zsq.git
 ```
-2. Adding an alias
+2. Add an alias
+
 Adding an alias is different on different Operating Systems. Check yours below!
 
 #### macOS/Linux

--- a/README.md
+++ b/README.md
@@ -14,13 +14,16 @@ $ git clone https://github.com/JBYT27/zsq.git
 Adding an alias is different on different Operating Systems. Check yours below!
 
 #### macOS/Linux
-Find your `.zshrc` or `.bashrc` files and add the following code:
+Create a `.zshrc` or `.bashrc` files and add the following code:
 ```zsh
 alias zsq="python $HOME/zsq/main.py"
 ```
 
 #### Windows
-
+Create a `.bashrc` files and add the following code:
+```zsh
+alias zsq="python $HOME/zsq/main.py"
+```
 
 ---
 


### PR DESCRIPTION
Added syntax highlighting for CLI commands and added instruction for macOS/Linux for adding `zsq` alias.

If you use Windows you might want to add instructions for it.